### PR TITLE
Fixes writing to private channels

### DIFF
--- a/lib/Slack/RTM/Bot.pm
+++ b/lib/Slack/RTM/Bot.pm
@@ -96,7 +96,7 @@ sub say {
 					subtype => 'bot_message',
 					bot_id  => $self->{client}->{info}->{self}->{id},
 					%$args,
-					channel => $self->{client}->{info}->_find_channel_id($args->{channel}),
+					channel => $self->{client}->{info}->_find_channel_or_group_id($args->{channel}),
 			}) . "\n";
 }
 

--- a/lib/Slack/RTM/Bot/Information.pm
+++ b/lib/Slack/RTM/Bot/Information.pm
@@ -42,6 +42,14 @@ sub _parse_groups {
 	return $groups;
 }
 
+sub _find_channel_or_group_id {
+	my $self = shift;
+	my ($name) = @_;
+	return $self->_find_channel_id($name) ||
+        $self->_find_group_id($name) ||
+        die "There are no channels or groups of such name: $name";
+}
+
 sub _find_channel_id {
 	my $self = shift;
 	my ($name) = @_;
@@ -51,15 +59,39 @@ sub _find_channel_id {
 			return $channels->{$key}->{id};
 		}
 	}
-	die "There are no channels of such name: $name";
+}
+
+sub _find_group_id {
+	my $self = shift;
+	my ($name) = @_;
+	my $groups = $self->{groups};
+	for my $key (keys %{$groups}){
+		if($name eq $groups->{$key}->{name}){
+			return $groups->{$key}->{id};
+		}
+	}
+}
+
+sub _find_channel_or_group_name {
+	my $self = shift;
+	my ($id) = @_;
+    $self->_find_channel_name($id) ||
+        $self->_find_group_name($id) ||
+        die "There are no channels or groups of such id: $id";
 }
 
 sub _find_channel_name {
 	my $self = shift;
 	my ($id) = @_;
 	my $channels = $self->{channels};
-	$channels->{$id} or die "There are no channels of such id: $id";
-	return $channels->{$id}->{name};
+	$channels->{$id}->{name} if $channels->{$id};
+}
+
+sub _find_group_name {
+	my $self = shift;
+	my ($id) = @_;
+	my $groups = $self->{groups};
+	$groups->{$id}->{name} if $groups->{$id};
 }
 
 sub _find_user_name {

--- a/lib/Slack/RTM/Bot/Response.pm
+++ b/lib/Slack/RTM/Bot/Response.pm
@@ -8,7 +8,7 @@ sub new {
 	my $args = {@_};
 	my $self = {%{$args->{buffer}}};
 	$self->{user} = $args->{info}->_find_user_name($self->{user}) if $self->{user} && !ref( $self->{user} );
-	$self->{channel} = $args->{info}->_find_channel_name($self->{channel}) if $self->{channel} && !ref( $self->{channel} );
+	$self->{channel} = $args->{info}->_find_channel_or_group_name($self->{channel}) if $self->{channel} && !ref( $self->{channel} );
 	return bless $self, $pkg;
 }
 


### PR DESCRIPTION
When reading or writing from private channels the bot dies
because it only check the list of "channels" inside information and
the it ignores "groups" which is where the private channels' data is
stored.

This PR adds a check on the groups which is readily available inside the
information object when reading and writing a message.
