### PR TITLE
Slack changed the limit maximum

### DIFF
--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -155,13 +155,23 @@ sub _refetch_conversation_name {
 
 sub _refetch_conversations {
 	my $self = shift;
-	my $res = $ua->request(GET "https://slack.com/api/conversations.list?limit=999999999&types=public_channel,private_channel,mpim,im&token=$self->{token}");
+	my $res;
 	eval {
-		$self->{info}->{channels} = Slack::RTM::Bot::Information::_parse_conversations(JSON::from_json($res->content));
-	};
-	if ($@) {
-		die '_refetch_conversations response fail:'.Dumper $res->content;
-	}
+		my $conversations = {};
+		my $cursor = "";
+		do {
+			$res = $ua->request(GET "https://slack.com/api/conversations.list?types=public_channel,private_channel&token=$self->{token}&cursor=$cursor&limit=1000");
+			my $args = JSON::from_json($res->content);
+			for my $conversation (@{$args->{channels}}) {
+				$conversations->{$conversation->{id}} = $conversation;
+			}
+			$cursor = $args->{response_metadata}->{next_cursor};
+		} until ($cursor eq "")
+		$self->{info}->{channels} = $conversations;
+       };
+       if ($@) {
+	       die '_refetch_conversations response fail:'.Dumper $res->content;
+       }
 }
 
 sub find_user_name {


### PR DESCRIPTION
Right after setting the limit obscenely high Slack seems to have reduced the limit to a hard 1000. Pagination support is now required for both users and conversations (if you have over 1000 of either), otherwise the module die()'s at inopportune times. 