### PR TITLE
Users -> Members fix

### DIFF
--- a/lib/Slack/RTM/Bot.pm
+++ b/lib/Slack/RTM/Bot.pm
@@ -187,29 +187,6 @@ sub say {
 	print WRITEH $request;
 }
 
-sub sayid {
-	my $self = shift;
-	my $args;
-	if(!@_ || scalar @_ % 2 != 0) {
-		die "argument is not a HASH or ARRAY."
-	}
-	$args = {@_};
-	if(!defined $args->{text} || !defined $args->{channel}) {
-		die "argument needs keys 'text' and 'channel'.";
-	}
-
-	die "RTM not started." unless $self->{client};
-
-	my $request = JSON::to_json({
-		type    => 'message',
-		subtype => 'bot_message',
-		bot_id  => $self->{client}->{info}->{self}->{id},
-		%$args,
-		channel => $args->{channel}
-	})."\n";
-	print WRITEH $request;
-}
-
 sub on {
 	my $self = shift;
 	die "RTM already started." if $self->{info};

--- a/lib/Slack/RTM/Bot.pm
+++ b/lib/Slack/RTM/Bot.pm
@@ -187,6 +187,29 @@ sub say {
 	print WRITEH $request;
 }
 
+sub sayid {
+	my $self = shift;
+	my $args;
+	if(!@_ || scalar @_ % 2 != 0) {
+		die "argument is not a HASH or ARRAY."
+	}
+	$args = {@_};
+	if(!defined $args->{text} || !defined $args->{channel}) {
+		die "argument needs keys 'text' and 'channel'.";
+	}
+
+	die "RTM not started." unless $self->{client};
+
+	my $request = JSON::to_json({
+		type    => 'message',
+		subtype => 'bot_message',
+		bot_id  => $self->{client}->{info}->{self}->{id},
+		%$args,
+		channel => $args->{channel}
+	})."\n";
+	print WRITEH $request;
+}
+
 sub on {
 	my $self = shift;
 	die "RTM already started." if $self->{info};

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -6,8 +6,6 @@ use warnings;
 use JSON;
 use Encode;
 use Data::Dumper;
-use Data::Printer;
-
 
 use HTTP::Request::Common qw(POST GET);
 use LWP::UserAgent;
@@ -26,7 +24,6 @@ my $ua = LWP::UserAgent->new(
 	}
 );
 $ua->agent('Slack::RTM::Bot');
-$ua->timeout(120);
 
 sub new {
 	my $pkg = shift;
@@ -41,15 +38,15 @@ sub connect {
 	my $self = shift;
 	my ($token) = @_;
 
-	my $res = $ua->request(POST 'https://slack.com/api/rtm.connect', [ token => $token ]);
+	my $res = $ua->request(POST 'https://slack.com/api/rtm.start', [ token => $token ]);
 	my $content;
 	eval {
 		$content = JSON::from_json($res->content);
 	};
 	if ($@) {
-		die 'connect response fail 00:'.Dumper $res->content;
+		die 'connect response fail:'.Dumper $res->content;
 	}
-	die 'connect response fail 1: '.$res->content unless ($content->{ok});
+	die 'connect response fail: '.$res->content unless ($content->{ok});
 
 	$self->{info} = Slack::RTM::Bot::Information->new(%{$content});
 	$res = $ua->request(POST 'https://slack.com/api/conversations.list ', [ token => $token ]);
@@ -57,9 +54,9 @@ sub connect {
 		$content = JSON::decode_json($res->content);
 	};
 	if ($@) {
-		die 'connect response fail 01:'.Dumper $res->content;
+		die 'connect response fail:'.Dumper $res->content;
 	}
-	die 'connect response fail 2: '.$res->content unless ($content->{ok});
+	die 'connect response fail: '.$res->content unless ($content->{ok});
 
 	for my $im (@{$content->{channels}}) {
 		$self->{info}->{channels}->{$im->{id}} = { %$im, name => '@'.$im->{name} };
@@ -96,9 +93,7 @@ sub _connect {
 			my ($cli, $error) = @_;
 			print STDERR 'error: '. $error;
 		});
-	print "preconnect\n";
-	p $ws_client->connect;
-	print "postconnect\n";
+	$ws_client->connect;
 
 	$self->{ws_client} = $ws_client;
 	$self->{socket} = $socket;

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -6,6 +6,8 @@ use warnings;
 use JSON;
 use Encode;
 use Data::Dumper;
+use Data::Printer;
+
 
 use HTTP::Request::Common qw(POST GET);
 use LWP::UserAgent;
@@ -24,6 +26,7 @@ my $ua = LWP::UserAgent->new(
 	}
 );
 $ua->agent('Slack::RTM::Bot');
+$ua->timeout(120);
 
 sub new {
 	my $pkg = shift;
@@ -38,15 +41,15 @@ sub connect {
 	my $self = shift;
 	my ($token) = @_;
 
-	my $res = $ua->request(POST 'https://slack.com/api/rtm.start', [ token => $token ]);
+	my $res = $ua->request(POST 'https://slack.com/api/rtm.connect', [ token => $token ]);
 	my $content;
 	eval {
 		$content = JSON::from_json($res->content);
 	};
 	if ($@) {
-		die 'connect response fail:'.Dumper $res->content;
+		die 'connect response fail 00:'.Dumper $res->content;
 	}
-	die 'connect response fail: '.$res->content unless ($content->{ok});
+	die 'connect response fail 1: '.$res->content unless ($content->{ok});
 
 	$self->{info} = Slack::RTM::Bot::Information->new(%{$content});
 	$res = $ua->request(POST 'https://slack.com/api/im.list', [ token => $token ]);
@@ -54,9 +57,9 @@ sub connect {
 		$content = JSON::from_json($res->content);
 	};
 	if ($@) {
-		die 'connect response fail:'.Dumper $res->content;
+		die 'connect response fail 01:'.Dumper $res->content;
 	}
-	die 'connect response fail: '.$res->content unless ($content->{ok});
+	die 'connect response fail 2: '.$res->content unless ($content->{ok});
 
 	for my $im (@{$content->{ims}}) {
 		my $name = $self->{info}->_find_user_name($im->{user});
@@ -94,7 +97,9 @@ sub _connect {
 			my ($cli, $error) = @_;
 			print STDERR 'error: '. $error;
 		});
-	$ws_client->connect;
+	print "preconnect\n";
+	p $ws_client->connect;
+	print "postconnect\n";
 
 	$self->{ws_client} = $ws_client;
 	$self->{socket} = $socket;

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -211,10 +211,12 @@ sub _refetch_users {
 		do {
 			$res = $ua->request(GET "https://slack.com/api/users.list?token=$self->{token}&cursor=$cursor");
 			my $args = JSON::from_json($res->content);
-			for my $user (@{$args->{users}}) {
+			for my $user (@{$args->{members}}) {
 				$users->{$user->{id}} = $user;
 			}
-			$cursor = $args->{response_metadata}->{next_cursor};
+			if (defined($args->{response_metadata}->{next_cursor})) {
+				$cursor = $args->{response_metadata}->{next_cursor};
+			}
 		} until ($cursor eq "");
 		$self->{info}->{users} = $users;
        };


### PR DESCRIPTION
Slack changed from 'users' to 'members', this was causing repeated calls to users.list since it was never populated. 

I think this fixes #22 as well. 

Also fixes a perl warning related to next_cursor (Slack stopped sending empty cursors) 