### PR TITLE
rtm.start -> rtm.connect

### DIFF
--- a/lib/Slack/RTM/Bot.pm
+++ b/lib/Slack/RTM/Bot.pm
@@ -187,29 +187,6 @@ sub say {
 	print WRITEH $request;
 }
 
-sub sayid {
-	my $self = shift;
-	my $args;
-	if(!@_ || scalar @_ % 2 != 0) {
-		die "argument is not a HASH or ARRAY."
-	}
-	$args = {@_};
-	if(!defined $args->{text} || !defined $args->{channel}) {
-		die "argument needs keys 'text' and 'channel'.";
-	}
-
-	die "RTM not started." unless $self->{client};
-
-	my $request = JSON::to_json({
-		type    => 'message',
-		subtype => 'bot_message',
-		bot_id  => $self->{client}->{info}->{self}->{id},
-		%$args,
-		channel => $args->{channel}
-	})."\n";
-	print WRITEH $request;
-}
-
 sub on {
 	my $self = shift;
 	die "RTM already started." if $self->{info};

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -6,7 +6,6 @@ use warnings;
 use JSON;
 use Encode;
 use Data::Dumper;
-use Data::Printer;
 
 
 use HTTP::Request::Common qw(POST GET);
@@ -26,7 +25,6 @@ my $ua = LWP::UserAgent->new(
 	}
 );
 $ua->agent('Slack::RTM::Bot');
-$ua->timeout(120);
 
 sub new {
 	my $pkg = shift;
@@ -49,7 +47,7 @@ sub connect {
 	if ($@) {
 		die 'connect response fail 00:'.Dumper $res->content;
 	}
-	die 'connect response fail 1: '.$res->content unless ($content->{ok});
+	die 'connect response fail 01: '.$res->content unless ($content->{ok});
 
 	$self->{info} = Slack::RTM::Bot::Information->new(%{$content});
 	$res = $ua->request(POST 'https://slack.com/api/conversations.list ', [ token => $token ]);
@@ -57,9 +55,9 @@ sub connect {
 		$content = JSON::decode_json($res->content);
 	};
 	if ($@) {
-		die 'connect response fail 01:'.Dumper $res->content;
+		die 'connect response fail 02:'.Dumper $res->content;
 	}
-	die 'connect response fail 2: '.$res->content unless ($content->{ok});
+	die 'connect response fail 03: '.$res->content unless ($content->{ok});
 
 	for my $im (@{$content->{channels}}) {
 		$self->{info}->{channels}->{$im->{id}} = { %$im, name => '@'.$im->{name} };
@@ -96,9 +94,7 @@ sub _connect {
 			my ($cli, $error) = @_;
 			print STDERR 'error: '. $error;
 		});
-	print "preconnect\n";
-	p $ws_client->connect;
-	print "postconnect\n";
+	$ws_client->connect;
 
 	$self->{ws_client} = $ws_client;
 	$self->{socket} = $socket;

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -207,12 +207,10 @@ sub _refetch_users {
 		do {
 			$res = $ua->request(GET "https://slack.com/api/users.list?token=$self->{token}&cursor=$cursor");
 			my $args = JSON::from_json($res->content);
-			for my $user (@{$args->{members}}) {
+			for my $user (@{$args->{users}}) {
 				$users->{$user->{id}} = $user;
 			}
-			if (defined($args->{response_metadata}->{next_cursor})) {
-				$cursor = $args->{response_metadata}->{next_cursor};
-			}
+			$cursor = $args->{response_metadata}->{next_cursor};
 		} until ($cursor eq "");
 		$self->{info}->{users} = $users;
        };

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -7,7 +7,6 @@ use JSON;
 use Encode;
 use Data::Dumper;
 
-
 use HTTP::Request::Common qw(POST GET);
 use LWP::UserAgent;
 use LWP::Protocol::https;

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -211,10 +211,12 @@ sub _refetch_users {
 		do {
 			$res = $ua->request(GET "https://slack.com/api/users.list?token=$self->{token}&cursor=$cursor");
 			my $args = JSON::from_json($res->content);
-			for my $user (@{$args->{users}}) {
+			for my $user (@{$args->{members}}) {
 				$users->{$user->{id}} = $user;
 			}
-			$cursor = $args->{response_metadata}->{next_cursor};
+			if (defined($args->{response_metadata}->{next_cursor})) {
+				$cursor = $args->{response_metadata}->{next_cursor};
+			}
 		} until ($cursor eq "");
 		$self->{info}->{users} = $users;
        };


### PR DESCRIPTION
Slack instances that have grown to a certain size are no longer able to use rtm.start due to a timeout on Slack's API servers. 

The solution is to use rtm.connect (which does not include user+channel information), which will then trigger users+channels fetch after connecting. 