### PR TITLE
Use rtm.connect instead of rtm.start

### DIFF
--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -6,7 +6,6 @@ use warnings;
 use JSON;
 use Encode;
 use Data::Dumper;
-use Data::Printer;
 
 
 use HTTP::Request::Common qw(POST GET);
@@ -26,7 +25,6 @@ my $ua = LWP::UserAgent->new(
 	}
 );
 $ua->agent('Slack::RTM::Bot');
-$ua->timeout(120);
 
 sub new {
 	my $pkg = shift;
@@ -49,7 +47,7 @@ sub connect {
 	if ($@) {
 		die 'connect response fail 00:'.Dumper $res->content;
 	}
-	die 'connect response fail 1: '.$res->content unless ($content->{ok});
+	die 'connect response fail 01: '.$res->content unless ($content->{ok});
 
 	$self->{info} = Slack::RTM::Bot::Information->new(%{$content});
 	$res = $ua->request(POST 'https://slack.com/api/conversations.list ', [ token => $token ]);
@@ -57,9 +55,9 @@ sub connect {
 		$content = JSON::decode_json($res->content);
 	};
 	if ($@) {
-		die 'connect response fail 01:'.Dumper $res->content;
+		die 'connect response fail 02:'.Dumper $res->content;
 	}
-	die 'connect response fail 2: '.$res->content unless ($content->{ok});
+	die 'connect response fail 03: '.$res->content unless ($content->{ok});
 
 	for my $im (@{$content->{channels}}) {
 		$self->{info}->{channels}->{$im->{id}} = { %$im, name => '@'.$im->{name} };
@@ -96,9 +94,7 @@ sub _connect {
 			my ($cli, $error) = @_;
 			print STDERR 'error: '. $error;
 		});
-	print "preconnect\n";
-	p $ws_client->connect;
-	print "postconnect\n";
+	$ws_client->connect;
 
 	$self->{ws_client} = $ws_client;
 	$self->{socket} = $socket;

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -37,7 +37,7 @@ sub connect {
 	my $self = shift;
 	my ($token) = @_;
 
-	my $res = $ua->request(POST 'https://slack.com/api/rtm.start', [ token => $token ]);
+	my $res = $ua->request(POST 'https://slack.com/api/rtm.connect', [ token => $token ]);
 	my $content;
 	eval {
 		$content = JSON::from_json($res->content);

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -6,11 +6,6 @@ use warnings;
 use JSON;
 use Encode;
 use Data::Dumper;
-<<<<<<< HEAD
-
-=======
->>>>>>> 5b7eacee6f026f139a30a76c1bb985e5fab4e12a
-
 use HTTP::Request::Common qw(POST GET);
 use LWP::UserAgent;
 use LWP::Protocol::https;

--- a/lib/Slack/RTM/Bot/Client.pm
+++ b/lib/Slack/RTM/Bot/Client.pm
@@ -211,10 +211,12 @@ sub _refetch_users {
 		do {
 			$res = $ua->request(GET "https://slack.com/api/users.list?token=$self->{token}&cursor=$cursor");
 			my $args = JSON::from_json($res->content);
-			for my $user (@{$args->{users}}) {
+			for my $user (@{$args->{members}}) {
 				$users->{$user->{id}} = $user;
 			}
-			$cursor = $args->{response_metadata}->{next_cursor};
+			if (defined($args->{response_metadata}->{next_cursor})) {
+				$cursor = $args->{response_metadata}->{next_cursor};
+			}
 		} until ($cursor eq "");
 		$self->{info}->{users} = $users;
        };


### PR DESCRIPTION
rtm.start stops working after your slack instance grows to a certain size. Their developers recommend using rtm.connect then conversations.list. 